### PR TITLE
Fix "St. George" typo

### DIFF
--- a/client/src/components/MainPage.js
+++ b/client/src/components/MainPage.js
@@ -33,7 +33,7 @@ const MainPage = () => {
               className={instructions_class}
               style={{ fontSize: instructions_fontsize }}
             >
-              Find &amp; Upload Group Chats for Courses at the UofT St.George
+              Find &amp; Upload Group Chats for Courses at the UofT St. George
               Campus
             </h3>
             <SearchBar isPhone={isPhone} />


### PR DESCRIPTION
Fixed typo on main page by changing `St.George` to `St. George` (added space after period).